### PR TITLE
Allow recording of specific resource types

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -232,7 +232,7 @@ locals {
   enabled = module.this.enabled && !contains(var.disabled_aggregation_regions, data.aws_region.this.name)
 
   is_central_account                = var.central_resource_collector_account == data.aws_caller_identity.this.account_id
-  is_global_recorder_region         = var.global_resource_collector_region == data.aws_region.this.name
+  is_global_recorder_region         = var.resource_types == null ? var.global_resource_collector_region == data.aws_region.this.name : false
   child_resource_collector_accounts = var.child_resource_collector_accounts != null ? var.child_resource_collector_accounts : []
   enable_notifications              = module.this.enabled && (var.create_sns_topic || var.findings_notification_arn != null)
   create_sns_topic                  = module.this.enabled && var.create_sns_topic

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,8 @@ resource "aws_config_configuration_recorder" "recorder" {
   name     = module.aws_config_label.id
   role_arn = local.create_iam_role ? module.iam_role[0].arn : var.iam_role_arn
   recording_group {
-    all_supported                 = true
+    all_supported                 = var.resource_types == null ? false : true
+    resource_types                = var.resource_types
     include_global_resource_types = local.is_global_recorder_region
   }
 }
@@ -228,7 +229,7 @@ data "aws_region" "this" {}
 data "aws_caller_identity" "this" {}
 
 locals {
-  enabled = module.this.enabled && ! contains(var.disabled_aggregation_regions, data.aws_region.this.name)
+  enabled = module.this.enabled && !contains(var.disabled_aggregation_regions, data.aws_region.this.name)
 
   is_central_account                = var.central_resource_collector_account == data.aws_caller_identity.this.account_id
   is_global_recorder_region         = var.global_resource_collector_region == data.aws_region.this.name

--- a/modules/cis-1-2-rules/main.tf
+++ b/modules/cis-1-2-rules/main.tf
@@ -10,9 +10,9 @@ locals {
   region_exclusion_tag    = "region/excluded/${local.current_region}"
 
   tagged_rules          = { for key, rule in local.rules_with_tags : key => rule if lookup(rule.tags, local.compliance_standard_tag, false) == true }
-  logging_account_rules = { for key, rule in local.tagged_rules : key => rule if var.is_logging_account && lookup(rule.tags, local.logging_only_tag, false) && ! lookup(rule.tags, local.region_exclusion_tag, false) }
-  global_resource_rules = { for key, rule in local.tagged_rules : key => rule if var.is_global_resource_region && lookup(rule.tags, local.global_only_tag, false) && ! lookup(rule.tags, local.region_exclusion_tag, false) }
-  base_rules            = { for key, rule in local.tagged_rules : key => rule if(! lookup(rule.tags, local.logging_only_tag, false) && ! lookup(rule.tags, local.global_only_tag, false) && ! lookup(rule.tags, local.region_exclusion_tag, false)) }
+  logging_account_rules = { for key, rule in local.tagged_rules : key => rule if var.is_logging_account && lookup(rule.tags, local.logging_only_tag, false) && !lookup(rule.tags, local.region_exclusion_tag, false) }
+  global_resource_rules = { for key, rule in local.tagged_rules : key => rule if var.is_global_resource_region && lookup(rule.tags, local.global_only_tag, false) && !lookup(rule.tags, local.region_exclusion_tag, false) }
+  base_rules            = { for key, rule in local.tagged_rules : key => rule if(!lookup(rule.tags, local.logging_only_tag, false) && !lookup(rule.tags, local.global_only_tag, false) && !lookup(rule.tags, local.region_exclusion_tag, false)) }
   all_rules             = merge(local.base_rules, local.logging_account_rules, local.global_resource_rules)
 
   base_params = {

--- a/variables.tf
+++ b/variables.tf
@@ -151,3 +151,4 @@ variable "resource_types" {
   default     = null
   description = "A list that specifies the types of AWS resources for which AWS Config records configuration changes (for example, AWS::EC2::Instance or AWS::CloudTrail::Trail)."
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -145,3 +145,9 @@ variable "disabled_aggregation_regions" {
   description = "A list of regions where config aggregation is disabled"
   default     = ["ap-northeast-3"]
 }
+
+variable "resource_types" {
+  type        = list(string)
+  default     = null
+  description = "A list that specifies the types of AWS resources for which AWS Config records configuration changes (for example, AWS::EC2::Instance or AWS::CloudTrail::Trail)."
+}


### PR DESCRIPTION
## what
* Allow the user to only record specific resource types instead of 
* Default behavior is still to record all resource types

## why
* Recording all resource types incurs more cost
* Not all recorded resources are of interest to the user, especially if the main use case is for security

## references
* This should resolve this issue https://github.com/cloudposse/terraform-aws-config/issues/38

